### PR TITLE
Fix `engines.node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18.20"
+		"node": ">=18.20 <19 >=20.10.0"
 	},
 	"scripts": {
 		"//test": "xo && ava && tsc --noEmit index.d.ts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18.20 <19 >=20.10.0"
+		"node": ">=18.20 <19 || >=20.10"
 	},
 	"scripts": {
 		"//test": "xo && ava && tsc --noEmit index.d.ts",


### PR DESCRIPTION
- See https://github.com/sindresorhus/boxen/pull/102

I think all modules using import attributes should have this `engines`

Verified on https://jubianchi.github.io/semver-check/#/%3E%3D18.20%20%3C19%20||%20%3E%3D20.10/19


Also, why not set `"exports": "boxes.json"`?